### PR TITLE
Add ACL property for uploading swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,6 @@ custom:
   swaggerDestinations:
     s3BucketName: 'bucket-name'
     s3KeyName: 'swagger/api.json'
+    # optional, default: private
+    acl: public-read
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ const exportApi = function exportApi(serverless) {
               && 's3KeyName' in settings.swaggerDestinations
             ) {
               var acl = 'private';
-              if ('ACL' in settings.swaggerDestinations) {
+              if ('acl' in settings.swaggerDestinations) {
                 acl = settings.swaggerDestinations.acl;
               }
               serverless.getProvider('aws').request(

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,10 @@ const exportApi = function exportApi(serverless) {
               's3BucketName' in settings.swaggerDestinations
               && 's3KeyName' in settings.swaggerDestinations
             ) {
+              var acl = 'private';
+              if ('ACL' in settings.swaggerDestinations) {
+                acl = settings.swaggerDestinations.acl;
+              }
               serverless.getProvider('aws').request(
                 'S3',
                 'putObject',
@@ -56,6 +60,7 @@ const exportApi = function exportApi(serverless) {
                   Body: r.body,
                   Bucket: settings.swaggerDestinations.s3BucketName,
                   Key: settings.swaggerDestinations.s3KeyName,
+                  ACL: acl
                 },
                 serverless.getProvider('aws').getStage(),
                 serverless.getProvider('aws').getRegion(),


### PR DESCRIPTION
I want to use the api.json directly with my swagger-ui app, this PR will make it so the file can be uploaded as `public-read` or whatever canned ACL you want directly.